### PR TITLE
support restoring permissions and last modification times

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -4,11 +4,14 @@ import (
 	"archive/tar"
 	"errors"
 	"fmt"
+	fs "github.com/ipfs/go-ipfs-files"
 	"io"
 	"io/ioutil"
 	"os"
 	fp "path/filepath"
+	"runtime"
 	"strings"
+	"time"
 )
 
 var errTraverseSymlink = errors.New("cannot traverse symlinks")
@@ -25,11 +28,14 @@ var errInvalidRootMultipleRoots = fmt.Errorf("contains more than one root or the
 // `cp`. In particular, the name of the extracted file/symlink will match the extraction path. If the extraction path
 // is a directory then it will extract into the directory using its original name.
 //
+// If an associated mode and last modification time was stored in the archive it is restored.
+//
 // Overwriting: Extraction of files and symlinks will result in overwriting the existing objects with the same name
 // when possible (i.e. other files, symlinks, and empty directories).
 type Extractor struct {
-	Path     string
-	Progress func(int64) int64
+	Path            string
+	Progress        func(int64) int64
+	deferredUpdates []deferredUpdate
 }
 
 // Extract extracts a tar file to the file system. See the Extractor for more information on the limitations on the
@@ -39,9 +45,9 @@ func (te *Extractor) Extract(reader io.Reader) error {
 		return nil
 	}
 
-	tarReader := tar.NewReader(reader)
-
 	var firstObjectWasDir bool
+	tarReader := tar.NewReader(reader)
+	te.deferredUpdates = make([]deferredUpdate, 0, 80)
 
 	header, err := tarReader.Next()
 	if err != nil && err != io.EOF {
@@ -50,6 +56,19 @@ func (te *Extractor) Extract(reader io.Reader) error {
 	if header == nil || err == io.EOF {
 		return fmt.Errorf("empty tar file")
 	}
+
+	doUpdates := func() error {
+		for i := len(te.deferredUpdates) - 1; i >= 0; i-- {
+			m := te.deferredUpdates[i]
+			err := updateMeta(m.path, m.mode, m.mtime)
+			if err != nil {
+				return err
+			}
+		}
+		te.deferredUpdates = nil
+		return nil
+	}
+	defer func() { err = doUpdates() }()
 
 	// Specially handle the first entry assuming it is a single root object (e.g. root directory, single file,
 	// or single symlink)
@@ -84,6 +103,10 @@ func (te *Extractor) Extract(reader io.Reader) error {
 		if err := te.extractDir(rootOutputPath); err != nil {
 			return err
 		}
+		if err := te.deferUpdate(rootOutputPath, header); err != nil {
+			return err
+		}
+
 	case tar.TypeReg, tar.TypeSymlink:
 		// Check if the output path already exists, so we know whether we should
 		// create our output with that name, or if we should put the output inside
@@ -114,6 +137,9 @@ func (te *Extractor) Extract(reader io.Reader) error {
 		// If an object with the target name already exists overwrite it
 		if header.Typeflag == tar.TypeReg {
 			if err := te.extractFile(outputPath, tarReader); err != nil {
+				return err
+			}
+			if err := updateMeta(outputPath, header.Mode, header.ModTime); err != nil {
 				return err
 			}
 		} else if err := te.extractSymlink(outputPath, header); err != nil {
@@ -172,8 +198,14 @@ func (te *Extractor) Extract(reader io.Reader) error {
 			if err := te.extractDir(outputPath); err != nil {
 				return err
 			}
+			if err := te.deferUpdate(outputPath, header); err != nil {
+				return err
+			}
 		case tar.TypeReg:
 			if err := te.extractFile(outputPath, tarReader); err != nil {
+				return err
+			}
+			if err := updateMeta(outputPath, header.Mode, header.ModTime); err != nil {
 				return err
 			}
 		case tar.TypeSymlink:
@@ -267,11 +299,22 @@ func (te *Extractor) extractDir(path string) error {
 }
 
 func (te *Extractor) extractSymlink(path string, h *tar.Header) error {
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+	err := os.Remove(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
-	return os.Symlink(h.Linkname, path)
+	err = os.Symlink(h.Linkname, path)
+	if err != nil {
+		return err
+	}
+
+	switch runtime.GOOS {
+	case "linux", "freebsd", "netbsd", "openbsd", "dragonfly":
+		return updateModTime(path, h.ModTime)
+	default:
+		return nil
+	}
 }
 
 func (te *Extractor) extractFile(path string, r *tar.Reader) error {
@@ -325,4 +368,68 @@ func copyWithProgress(to io.Writer, from io.Reader, cb func(int64) int64) error 
 			return err
 		}
 	}
+}
+
+type deferredUpdate struct {
+	path  string
+	mode  int64
+	mtime time.Time
+}
+
+func (te *Extractor) deferUpdate(path string, header *tar.Header) error {
+	if header.Mode == 0 && header.ModTime.IsZero() {
+		return nil
+	}
+
+	prefix := func() string {
+		for i := len(path) - 1; i >= 0; i-- {
+			if path[i] == '/' {
+				return path[:i]
+			}
+		}
+		return path
+	}
+
+	n := len(te.deferredUpdates)
+	if n > 0 && len(path) < len(te.deferredUpdates[n-1].path) {
+		// if possible, apply the previous deferral
+		m := te.deferredUpdates[n-1]
+		if strings.HasPrefix(m.path, prefix()) {
+			err := updateMeta(m.path, m.mode, m.mtime)
+			if err != nil {
+				return err
+			}
+			te.deferredUpdates = te.deferredUpdates[:n-1]
+		}
+	}
+
+	te.deferredUpdates = append(te.deferredUpdates, deferredUpdate{
+		path:  path,
+		mode:  header.Mode,
+		mtime: header.ModTime,
+	})
+
+	return nil
+}
+
+func updateMeta(path string, mode int64, mtime time.Time) error {
+	if err := updateModTime(path, mtime); err != nil {
+		return err
+	}
+	if mode != 0 {
+		if err := os.Chmod(path, fs.UnixPermsToModePerms(uint32(mode))); err != nil {
+			return fmt.Errorf("failed to update file mode on '%s'", path)
+		}
+	}
+	return nil
+}
+
+// updateModTime sets the last access and modification time of the target filesystem
+// object to the given time.
+// When the given path references a symlink, if supported the symlink is updated.
+func updateModTime(path string, mtime time.Time) error {
+	if err := updateMtime(path, mtime); err != nil {
+		return fmt.Errorf("[%v] failed to update last modification time on '%s'", path, err)
+	}
+	return nil
 }

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
+	fs "github.com/ipfs/go-ipfs-files"
 	"io"
 	"io/ioutil"
 	"os"
@@ -49,10 +50,33 @@ func TestSingleFile(t *testing.T) {
 	fileData := "file data"
 
 	testTarExtraction(t, nil, []tarEntry{
-		&fileTarEntry{fileName, []byte(fileData)},
+		&fileTarEntry{path: fileName, buf: []byte(fileData)},
 	},
 		func(t *testing.T, extractDir string) {
 			f, err := os.Open(fp.Join(extractDir, fileName))
+			assert.NoError(t, err)
+			data, err := ioutil.ReadAll(f)
+			assert.NoError(t, err)
+			assert.Equal(t, fileData, string(data))
+			assert.NoError(t, f.Close())
+		},
+		nil,
+	)
+}
+
+func TestSingleFileWithMeta(t *testing.T) {
+	fileName := "file2..ext"
+	fileData := "file2 data"
+	mode := 0654
+	mtime := time.Now().Round(time.Second)
+
+	testTarExtraction(t, nil, []tarEntry{
+		&fileTarEntry{path: fileName, buf: []byte(fileData), mode: mode, mtime: mtime},
+	},
+		func(t *testing.T, extractDir string) {
+			path := fp.Join(extractDir, fileName)
+			testMeta(t, path, mode, mtime)
+			f, err := os.Open(path)
 			assert.NoError(t, err)
 			data, err := ioutil.ReadAll(f)
 			assert.NoError(t, err)
@@ -67,9 +91,33 @@ func TestSingleDirectory(t *testing.T) {
 	dirName := "dir..sfx"
 
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{dirName},
+		&dirTarEntry{path: dirName},
 	},
 		func(t *testing.T, extractDir string) {
+			f, err := os.Open(extractDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			objs, err := f.Readdir(1)
+			if err == io.EOF && len(objs) == 0 {
+				return
+			}
+			t.Fatalf("expected an empty directory")
+		},
+		nil,
+	)
+}
+
+func TestSingleDirectoryWithMeta(t *testing.T) {
+	dirName := "dir2..sfx"
+	mode := 0765
+	mtime := time.Now().Round(time.Second)
+
+	testTarExtraction(t, nil, []tarEntry{
+		&dirTarEntry{path: dirName, mode: mode, mtime: mtime},
+	},
+		func(t *testing.T, extractDir string) {
+			testMeta(t, extractDir, mode, mtime)
 			f, err := os.Open(extractDir)
 			if err != nil {
 				t.Fatal(err)
@@ -89,8 +137,8 @@ func TestDirectoryFollowSymlinkToNothing(t *testing.T) {
 	childName := "child"
 
 	entries := []tarEntry{
-		&dirTarEntry{dirName},
-		&dirTarEntry{dirName + "/" + childName},
+		&dirTarEntry{path: dirName},
+		&dirTarEntry{path: dirName + "/" + childName},
 	}
 
 	testTarExtraction(t, func(t *testing.T, rootDir string) {
@@ -108,8 +156,8 @@ func TestDirectoryFollowSymlinkToFile(t *testing.T) {
 	childName := "child"
 
 	entries := []tarEntry{
-		&dirTarEntry{dirName},
-		&dirTarEntry{dirName + "/" + childName},
+		&dirTarEntry{path: dirName},
+		&dirTarEntry{path: dirName + "/" + childName},
 	}
 
 	testTarExtraction(t, func(t *testing.T, rootDir string) {
@@ -131,8 +179,8 @@ func TestDirectoryFollowSymlinkToDirectory(t *testing.T) {
 	childName := "child"
 
 	entries := []tarEntry{
-		&dirTarEntry{dirName},
-		&dirTarEntry{dirName + "/" + childName},
+		&dirTarEntry{path: dirName},
+		&dirTarEntry{path: dirName + "/" + childName},
 	}
 
 	testTarExtraction(t, func(t *testing.T, rootDir string) {
@@ -158,7 +206,7 @@ func TestSingleSymlink(t *testing.T) {
 	symlinkName := "symlink"
 
 	testTarExtraction(t, nil, []tarEntry{
-		&symlinkTarEntry{targetName, symlinkName},
+		&symlinkTarEntry{target: targetName, path: symlinkName},
 	}, func(t *testing.T, extractDir string) {
 		symlinkPath := fp.Join(extractDir, symlinkName)
 		fi, err := os.Lstat(symlinkPath)
@@ -176,37 +224,37 @@ func TestSingleSymlink(t *testing.T) {
 
 func TestMultipleRoots(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root"},
-		&dirTarEntry{"sibling"},
+		&dirTarEntry{path: "root"},
+		&dirTarEntry{path: "sibling"},
 	}, nil, errInvalidRoot)
 }
 
 func TestMultipleRootsNested(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root/child1"},
-		&dirTarEntry{"root/child2"},
+		&dirTarEntry{path: "root/child1"},
+		&dirTarEntry{path: "root/child2"},
 	}, nil, errInvalidRoot)
 }
 
 func TestOutOfOrderRoot(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root/child"},
-		&dirTarEntry{"root"},
+		&dirTarEntry{path: "root/child"},
+		&dirTarEntry{path: "root"},
 	}, nil, errInvalidRoot)
 }
 
 func TestOutOfOrder(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root/child/grandchild"},
-		&dirTarEntry{"root/child"},
+		&dirTarEntry{path: "root/child/grandchild"},
+		&dirTarEntry{path: "root/child"},
 	}, nil, errInvalidRoot)
 }
 
 func TestNestedDirectories(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root"},
-		&dirTarEntry{"root/child"},
-		&dirTarEntry{"root/child/grandchild"},
+		&dirTarEntry{path: "root"},
+		&dirTarEntry{path: "root/child"},
+		&dirTarEntry{path: "root/child/grandchild"},
 	}, func(t *testing.T, extractDir string) {
 		walkIndex := 0
 		err := fp.Walk(extractDir,
@@ -233,17 +281,127 @@ func TestNestedDirectories(t *testing.T) {
 
 func TestRootDirectoryHasSubpath(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root/child"},
-		&dirTarEntry{"root/child/grandchild"},
+		&dirTarEntry{path: "root/child"},
+		&dirTarEntry{path: "root/child/grandchild"},
 	}, nil, errInvalidRoot)
 }
 
 func TestFilesAndFolders(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
-		&dirTarEntry{"root"},
-		&dirTarEntry{"root/childdir"},
-		&fileTarEntry{"root/childdir/file1", []byte("some data")},
+		&dirTarEntry{path: "root"},
+		&dirTarEntry{path: "root/childdir"},
+		&fileTarEntry{path: "root/childdir/file1", buf: []byte("some data")},
 	}, nil, nil)
+}
+
+func TestFilesAndFoldersWithMetadata(t *testing.T) {
+	tm := time.Unix(660000000, 0)
+
+	entries := []tarEntry{
+		&dirTarEntry{path: "root", mtime: tm.Add(5 * time.Second)},
+		&dirTarEntry{path: "root/childdir", mode: 03775},
+		&fileTarEntry{path: "root/childdir/file1", buf: []byte("some data"), mode: 04764,
+			mtime: tm.Add(10 * time.Second)},
+	}
+
+	testTarExtraction(t, nil, entries, func(t *testing.T, extractDir string) {
+		walkIndex := 0
+		err := fp.Walk(extractDir,
+			func(path string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				switch walkIndex {
+				case 0:
+					assert.Equal(t, tm.Add(5*time.Second), fi.ModTime())
+				case 1:
+					assert.Equal(t, 0775, int(fi.Mode()&0xFFF))
+					assert.Equal(t, os.ModeSetgid, fi.Mode()&os.ModeSetgid)
+					assert.Equal(t, os.ModeSticky, fi.Mode()&os.ModeSticky)
+				case 2:
+					assert.Equal(t, 0764, int(fi.Mode()&0xFFF))
+					assert.Equal(t, os.ModeSetuid, fi.Mode()&os.ModeSetuid)
+					assert.Equal(t, tm.Add(10*time.Second), fi.ModTime())
+				default:
+					assert.Fail(t, "has more than 3 entries", path)
+				}
+				walkIndex++
+				return nil
+			})
+		assert.NoError(t, err)
+	},
+		nil)
+}
+
+func TestSymlinkWithModTime(t *testing.T) {
+	if !symlinksEnabled {
+		t.Skip("symlinks disabled on this platform", symlinksEnabledErr)
+	}
+	tm := time.Unix(660000000, 0)
+	add5 := func() time.Time {
+		tm = tm.Add(5 * time.Second)
+		return tm
+	}
+
+	entries := []tarEntry{
+		&dirTarEntry{path: "root"},
+		&symlinkTarEntry{target: "child", path: "root/a", mtime: add5()},
+		&dirTarEntry{path: "root/child"},
+		&fileTarEntry{path: "root/child/file1", buf: []byte("data")},
+		&symlinkTarEntry{target: "child/file1", path: "root/file1-sl", mtime: add5()},
+	}
+
+	testTarExtraction(t, nil, entries, func(t *testing.T, extractDir string) {
+		tm = time.Unix(660000000, 0)
+
+		fi, err := os.Lstat(fp.Join(extractDir, "a"))
+		assert.NoError(t, err)
+		assert.Equal(t, add5(), fi.ModTime())
+
+		fi, err = os.Lstat(fp.Join(extractDir, "file1-sl"))
+		assert.NoError(t, err)
+		assert.Equal(t, add5(), fi.ModTime())
+	},
+		nil)
+}
+
+func TestDeferredUpdate(t *testing.T) {
+	tm := time.Unix(660000000, 0)
+	add5 := func() time.Time {
+		tm = tm.Add(5 * time.Second)
+		return tm
+	}
+
+	// must be in lexical order
+	entries := []tarEntry{
+		&dirTarEntry{path: "root", mtime: add5()},
+		&dirTarEntry{path: "root/a", mtime: add5()},
+		&dirTarEntry{path: "root/a/beta", mtime: add5(), mode: 0500},
+		&dirTarEntry{path: "root/a/beta/centauri", mtime: add5()},
+		&dirTarEntry{path: "root/a/beta/lima", mtime: add5()},
+		&dirTarEntry{path: "root/a/beta/papa", mtime: add5()},
+		&dirTarEntry{path: "root/a/beta/xanadu", mtime: add5()},
+		&dirTarEntry{path: "root/a/beta/z", mtime: add5()},
+		&dirTarEntry{path: "root/a/delta", mtime: add5()},
+		&dirTarEntry{path: "root/iota", mtime: add5()},
+		&dirTarEntry{path: "root/q", mtime: add5()},
+	}
+
+	testTarExtraction(t, nil, entries, func(t *testing.T, extractDir string) {
+		tm = time.Unix(660000000, 0)
+		err := fp.Walk(extractDir,
+			func(path string, fi os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+
+				assert.Equal(t, add5(), fi.ModTime())
+				return nil
+			})
+		assert.NoError(t, err)
+	},
+		nil)
+
 }
 
 func TestInternalSymlinkTraverse(t *testing.T) {
@@ -253,10 +411,10 @@ func TestInternalSymlinkTraverse(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
 		// FIXME: We are ignoring the first element in the path check so
 		//  we add a directory at the start to bypass this.
-		&dirTarEntry{"root"},
-		&dirTarEntry{"root/child"},
-		&symlinkTarEntry{"child", "root/symlink-dir"},
-		&fileTarEntry{"root/symlink-dir/file", []byte("file")},
+		&dirTarEntry{path: "root"},
+		&dirTarEntry{path: "root/child"},
+		&symlinkTarEntry{target: "child", path: "root/symlink-dir"},
+		&fileTarEntry{path: "root/symlink-dir/file", buf: []byte("file")},
 	},
 		nil,
 		errTraverseSymlink,
@@ -270,9 +428,9 @@ func TestExternalSymlinkTraverse(t *testing.T) {
 	testTarExtraction(t, nil, []tarEntry{
 		// FIXME: We are ignoring the first element in the path check so
 		//  we add a directory at the start to bypass this.
-		&dirTarEntry{"inner"},
-		&symlinkTarEntry{"..", "inner/symlink-dir"},
-		&fileTarEntry{"inner/symlink-dir/file", []byte("overwrite content")},
+		&dirTarEntry{path: "inner"},
+		&symlinkTarEntry{target: "..", path: "inner/symlink-dir"},
+		&fileTarEntry{path: "inner/symlink-dir/file", buf: []byte("overwrite content")},
 	},
 		nil,
 		errTraverseSymlink,
@@ -294,9 +452,9 @@ func TestLastElementOverwrite(t *testing.T) {
 		assert.Equal(t, len(originalData), n)
 	},
 		[]tarEntry{
-			&dirTarEntry{"root"},
-			&symlinkTarEntry{"../outside-ref", "root/symlink"},
-			&fileTarEntry{"root/symlink", []byte("overwrite content")},
+			&dirTarEntry{path: "root"},
+			&symlinkTarEntry{target: "../outside-ref", path: "root/symlink"},
+			&fileTarEntry{path: "root/symlink", buf: []byte("overwrite content")},
 		},
 		func(t *testing.T, extractDir string) {
 			// Check that outside-ref still exists but has not been
@@ -357,6 +515,14 @@ func testExtract(t *testing.T, tarFile string, extractDir string, expectedError 
 	assert.ErrorIs(t, err, expectedError)
 }
 
+func testMeta(t *testing.T, path string, mode int, now time.Time) {
+	fi, err := os.Lstat(path)
+	assert.NoError(t, err)
+	m := fs.ModePermsToUnixPerms(fi.Mode())
+	assert.Equal(t, mode, int(m))
+	assert.Equal(t, now.Unix(), fi.ModTime().Unix())
+}
+
 // Based on the `writeXXXHeader` family of functions in
 // github.com/ipfs/go-ipfs-files@v0.0.8/tarwriter.go.
 func writeTarFile(t *testing.T, path string, entries []tarEntry) {
@@ -382,12 +548,14 @@ var _ tarEntry = (*dirTarEntry)(nil)
 var _ tarEntry = (*symlinkTarEntry)(nil)
 
 type fileTarEntry struct {
-	path string
-	buf  []byte
+	path  string
+	buf   []byte
+	mode  int
+	mtime time.Time
 }
 
 func (e *fileTarEntry) write(tw *tar.Writer) error {
-	if err := writeFileHeader(tw, e.path, uint64(len(e.buf))); err != nil {
+	if err := writeFileHeader(tw, e.path, uint64(len(e.buf)), e.mode, e.mtime); err != nil {
 		return err
 	}
 
@@ -398,34 +566,35 @@ func (e *fileTarEntry) write(tw *tar.Writer) error {
 	tw.Flush()
 	return nil
 }
-func writeFileHeader(w *tar.Writer, fpath string, size uint64) error {
+func writeFileHeader(w *tar.Writer, fpath string, size uint64, mode int, mtime time.Time) error {
 	return w.WriteHeader(&tar.Header{
 		Name:     fpath,
 		Size:     int64(size),
 		Typeflag: tar.TypeReg,
-		Mode:     0644,
-		ModTime:  time.Now(),
-		// TODO: set mode, dates, etc. when added to unixFS
+		Mode:     int64(mode),
+		ModTime:  mtime,
 	})
 }
 
 type dirTarEntry struct {
-	path string
+	path  string
+	mode  int
+	mtime time.Time
 }
 
 func (e *dirTarEntry) write(tw *tar.Writer) error {
 	return tw.WriteHeader(&tar.Header{
 		Name:     e.path,
 		Typeflag: tar.TypeDir,
-		Mode:     0777,
-		ModTime:  time.Now(),
-		// TODO: set mode, dates, etc. when added to unixFS
+		Mode:     int64(e.mode),
+		ModTime:  e.mtime,
 	})
 }
 
 type symlinkTarEntry struct {
 	target string
 	path   string
+	mtime  time.Time
 }
 
 func (e *symlinkTarEntry) write(w *tar.Writer) error {
@@ -433,6 +602,7 @@ func (e *symlinkTarEntry) write(w *tar.Writer) error {
 		Name:     e.path,
 		Linkname: e.target,
 		Mode:     0777,
+		ModTime:  e.mtime,
 		Typeflag: tar.TypeSymlink,
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require github.com/stretchr/testify v1.7.0
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/ipfs/go-ipfs-files v0.0.9
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20190302025703-b6889370fb10 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/util_other.go
+++ b/util_other.go
@@ -1,0 +1,16 @@
+// +build !linux
+// +build !freebsd
+// +build !netbsd
+// +build !openbsd
+// +build !dragonfly
+
+package tar
+
+import (
+	"os"
+	"time"
+)
+
+func updateMtime(path string, mtime time.Time) error {
+	return os.Chtimes(path, mtime, mtime)
+}

--- a/util_posix.go
+++ b/util_posix.go
@@ -1,0 +1,29 @@
+// +build linux freebsd netbsd openbsd dragonfly
+
+package tar
+
+import (
+	"golang.org/x/sys/unix"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+func updateMtime(path string, mtime time.Time) error {
+	var AtFdCwd = -100
+	pathname, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	tm := syscall.NsecToTimespec(mtime.UnixNano())
+	ts := [2]syscall.Timespec{tm, tm}
+	_, _, e := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(AtFdCwd),
+		uintptr(unsafe.Pointer(pathname)), uintptr(unsafe.Pointer(&ts)),
+		uintptr(unix.AT_SYMLINK_NOFOLLOW), 0, 0)
+	if e != 0 {
+		return error(e)
+	}
+
+	return nil
+}


### PR DESCRIPTION
When the TAR archive (headers) include a file mode or modification time, the extractor will restore that metadata when supported for the underlying filesystem.

_Would it make sense to move this functionality to  go-ipfs-files?_

### Related PRs
- ipfs/go-ipfs-files/pull/31